### PR TITLE
Don't pause the song while in a BeatLeader replay

### DIFF
--- a/BeatLeaderInterop.cs
+++ b/BeatLeaderInterop.cs
@@ -1,0 +1,31 @@
+﻿using IPA.Loader;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace PlayFirst
+{
+    internal class BeatLeaderInterop
+    {
+        public static bool IsBeatLeaderReplay()
+        {
+            PluginMetadata BeatLeader = PluginManager.GetPluginFromId("BeatLeader");
+            if (BeatLeader != null)
+            {
+                Type ReplayerLauncher = BeatLeader.Assembly.GetType("BeatLeader.Replayer.ReplayerLauncher");
+                if (ReplayerLauncher == null)
+                    return false;
+
+                PropertyInfo IsStartedAsReplay = ReplayerLauncher.GetProperty("IsStartedAsReplay", BindingFlags.Static | BindingFlags.Public);
+                if (IsStartedAsReplay == null)
+                    return false;
+
+                return (bool)IsStartedAsReplay.GetValue(null);
+            }
+            return false;
+        }
+    }
+}

--- a/PlayFirst.csproj
+++ b/PlayFirst.csproj
@@ -104,6 +104,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="BeatLeaderInterop.cs" />
     <Compile Include="SubmitLater.cs" />
     <Compile Include="CancelButtonViewController.cs" />
     <Compile Include="CancelButtonView.cs" />

--- a/SubmitLater.cs
+++ b/SubmitLater.cs
@@ -52,7 +52,10 @@ namespace PlayFirst
                 if (audiocontroller.songTime >= pausetime)
                 {
                     paused_yet = true;
-                    pausecontroller.Pause();
+                    if (!BeatLeaderInterop.IsBeatLeaderReplay())
+                    {
+                        pausecontroller.Pause();
+                    }
 
                     // Notes: PauseSong in SongController pauses map but isn't the whole "Pause" functionality
                     // Doesn't bring up menu, continue button won't work either.


### PR DESCRIPTION
This uses simple .NET Reflection to detect whether the currently active play is a BeatLeader replay and avoids pausing the song if it is. Tested with both BeatLeader installed and without.