### PR TITLE
Remove reference to `HMLib.dll`

### DIFF
--- a/PlayFirst.csproj
+++ b/PlayFirst.csproj
@@ -76,10 +76,6 @@
       <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\Main.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="HMLib">
-      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\HMLib.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
     <Reference Include="HMUI">
       <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\HMUI.dll</HintPath>
       <Private>False</Private>


### PR DESCRIPTION
That Reference is not used anywhere in this project so I removed it. I don't know if this is a universal issue or just one that affects me, but it caused the following error on my machine:

```TypeLoadException: Could not resolve type with token 0100004c from typeref (expected class 'PersistentSingleton`1' in assembly 'HMLib, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null')```